### PR TITLE
Implement post_connection_hook as a list of callbacks

### DIFF
--- a/src/swarm.erl
+++ b/src/swarm.erl
@@ -54,7 +54,12 @@ child_spec(Name, AcceptorCount, Transport, TransOpts, {M, F, A}) ->
 
 -spec add_post_connection_hook(function()) -> ok.
 add_post_connection_hook(Fun) when is_function(Fun) ->
-    put(swarm_post_connection_hook, Fun),
+    case get(swarm_post_connection_hook) of
+        undefined ->
+            put(swarm_post_connection_hook, [Fun]);
+        L ->
+            put(swarm_post_connection_hook, [Fun | L])
+    end,
     ok.
 
 

--- a/src/swarm_listener.erl
+++ b/src/swarm_listener.erl
@@ -109,6 +109,15 @@ post_connection_hook() ->
 post_connection_hook(undefined) ->
     ok;
 post_connection_hook(Fun) when is_function(Fun) ->
+    invoke_post_connection_hook(Fun);
+post_connection_hook(L) when is_list(L) ->
+    [invoke_post_connection_hook(Fun) || Fun <- L],
+    ok;
+post_connection_hook(_) ->
+    ok.
+
+
+invoke_post_connection_hook(Fun) when is_function(Fun) ->
     try
         Fun()
     catch
@@ -116,7 +125,7 @@ post_connection_hook(Fun) when is_function(Fun) ->
             ok
     end,
     ok;
-post_connection_hook(_) ->
+invoke_post_connection_hook(_) ->
     ok.
 
 


### PR DESCRIPTION
Makes post connection hooks into a list so more than one can be executed (to facilitate metric logging, etc.).

@motobob please review